### PR TITLE
Added send function which takes a pointer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ import os
 
 class TcpcatConan(ConanFile):
     name = "ydcpp-tcpcat"
-    version = "1.0.4"
+    version = "1.0.5"
     package_type = "library"
 
     # Optional metadata

--- a/include/tcpcat/base/EventHandler.h
+++ b/include/tcpcat/base/EventHandler.h
@@ -62,6 +62,12 @@ public:
     /// @param bytes Sent byte count.
     virtual void OnSent(std::shared_ptr<tcpcat::TcpSession> session, const std::vector<unsigned char> &buf, size_t bytes) {}
 
+    /// @brief Gets called when sent a message to peer.
+    /// @param session Session handle object.
+    /// @param buf Contains the sent bytes.
+    /// @param bytes Sent byte count.
+    virtual void OnSent(std::shared_ptr<tcpcat::TcpSession> session, const unsigned char* buf, size_t bytes) {}
+
     /// @brief Gets called when an error occurs.
     /// @param session Session handle object.
     /// @param err Error code object which holds error information.

--- a/include/tcpcat/base/TcpSession.h
+++ b/include/tcpcat/base/TcpSession.h
@@ -66,6 +66,13 @@ public:
     /// @return Returns the number of bytes sent.
     size_t Send(const std::vector<unsigned char> &buffer, size_t offset, size_t size);
 
+    /// @brief Sends data to the peer. Calls EventHandler->OnSent on success, EventHandler->OnError otherwise.
+    /// @param buffer Contains bytes to be sent.
+    /// @param offset Offset value from the beginning of `buffer`.
+    /// @param size Count of bytes to be sent starting from `offset`.
+    /// @return Returns the number of bytes sent.
+    size_t Send(const unsigned char* buffer, size_t offset, size_t size);
+
     /// @brief Sends data to the peer in non-blocking operation. Calls EventHandler->OnSent on success, EventHandler->OnError otherwise.
     /// @param buffer Contains bytes to be sent.
     /// @param offset Offset value from the beginning of `buffer`.

--- a/src/TcpSession.cpp
+++ b/src/TcpSession.cpp
@@ -95,6 +95,17 @@ size_t TcpSession::Send(const std::vector<unsigned char> &buffer, size_t offset,
     return sentBytes;
 }
 
+size_t TcpSession::Send(const unsigned char* buffer, size_t offset, size_t size)
+{
+    auto sharedThis = shared_from_this();
+
+    asio::error_code err;
+    const auto sentBytes = asio::write(*socket_, asio::buffer(buffer, offset + size), err);
+    sentBytes > 0 ? eventHandler_->OnSent(sharedThis, buffer, sentBytes) : eventHandler_->OnError(sharedThis, err);
+
+    return sentBytes;
+}
+
 void TcpSession::SendAsync(const std::vector<unsigned char> &buffer, size_t offset, size_t size)
 {
     auto sharedThis = shared_from_this();


### PR DESCRIPTION
Added a send function which takes a pointer to the data to send. This allows sending data from a known memory location without the overhead of copying the bytes to a vector.